### PR TITLE
Further work around of fixed log4j.

### DIFF
--- a/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/AlreadyFixedException.java
+++ b/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/AlreadyFixedException.java
@@ -1,0 +1,7 @@
+package moe.orangemc.shiina_xi_yu.antilog4jjndiexploit;
+
+public class AlreadyFixedException extends Exception {
+    public AlreadyFixedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/BungeeMain.java
+++ b/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/BungeeMain.java
@@ -25,7 +25,7 @@ public class BungeeMain extends Plugin
         catch (Throwable e)
         {
             getLogger().log(Level.SEVERE,
-                    "Here is some error when loading this plugin. For your security, closing server forced.",
+                    "I have encountered an error when loading this plugin. So I'll shut your server down forcefully for your security of the server.",
                     e);
             getProxy().stop();
         }
@@ -55,7 +55,7 @@ public class BungeeMain extends Plugin
         };
         reloadConfig();
         PluginManager pluginManager = getProxy().getPluginManager();
-        pluginManager.registerListener(this, new BungeePlayerClientPacketHandle());
+        pluginManager.registerListener(this, new BungeePlayerClientPacketHandler());
     }
 
     private void reloadConfig() throws IOException

--- a/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/BungeePlayerClientPacketHandler.java
+++ b/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/BungeePlayerClientPacketHandler.java
@@ -6,7 +6,7 @@ import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 
-public class BungeePlayerClientPacketHandle implements Listener
+public class BungeePlayerClientPacketHandler implements Listener
 {
     @EventHandler
     public void onChat(ChatEvent event)

--- a/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/JndiContextPatcher.java
+++ b/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/JndiContextPatcher.java
@@ -10,9 +10,13 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class JndiContextPatcher
 {
-    public static void initialize(Field field) throws IllegalAccessException
-    {
+    public static void initialize(Field field) throws IllegalAccessException, AlreadyFixedException {
         field.setAccessible(true);
+        try {
+            JndiManager.getDefaultManager();
+        } catch (IllegalStateException e) {
+            throw new AlreadyFixedException(e);
+        }
         field.set(JndiManager.getDefaultManager(), new Context()
         {
             private final AtomicLong lastBroadcastTime = new AtomicLong();

--- a/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/Main.java
+++ b/src/main/java/moe/orangemc/shiina_xi_yu/antilog4jjndiexploit/Main.java
@@ -76,33 +76,42 @@ public class Main extends JavaPlugin
             Class<?> type = contextField.getType();
             if (type == DirContext.class)
             {
-                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "The exploit of Log4j2 has been fixed in the current server,");
-                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "but we recommend you keep using this plugin to avoid client-side vulnerabilities. >w<");
-            } else if (contextField.getType() != Context.class)
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "The vulnerability of Log4j2 has already been fixed in your server,");
+                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "but I suggest you to keep me here to avoid client-side vulnerabilities. >w<");
+            } else if (!Context.class.isAssignableFrom(type))
             {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.LIGHT_PURPLE + "type=" + type);
                 Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "We can't fix this exploit for this version of Log4J2");
-                Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "For your server safely, we recommend you to shutdown your server now.");
-                Bukkit.getConsoleSender().sendMessage("=============================================================");
-                if (!forceStart)
-                {
-                    Bukkit.shutdown();
-                    return;
+                try {
+                    if (!forceStart) {
+                        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "I decided to shut your server down for your security.");
+                        Bukkit.shutdown();
+                        return;
+                    } else {
+                        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "But your server will start anyway. Keep in caution!");
+                    }
+                } finally {
+                    Bukkit.getConsoleSender().sendMessage("=============================================================");
                 }
             } else
             {
-                Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "Patching Log4J2.... Please wait...");
-                JndiContextPatcher.initialize(contextField);
+                Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "Patching Log4j2.... Please wait...");
+                try {
+                    JndiContextPatcher.initialize(contextField);
+                } catch (AlreadyFixedException e) {
+                    Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "This version of Log4j2 is already fixed. Skipping.");
+                }
             }
         } catch (Throwable e) {
             if (!forceStart) {
                 throw e;
             }
             e.printStackTrace();
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + "Force start is enabled. Proceed without server fix applied.");
+            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + "Forcefully start is enabled. Proceed without server fix applied.");
         }
         Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "Registering player packet monitor.... Please wait...");
         SpigotPlayerClientPacketHandle.initialize(this);
-        Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + "Fixed exploit of Log4J2. Have fun with ${jndi:}");
+        Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + "Fixed the vulnerability of Log4J2. Have fun with ${jndi:} payload :P");
         Bukkit.getConsoleSender().sendMessage("=============================================================");
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,8 +4,8 @@ message:
     # E.g.:
     # player-packet: ""
     # system: null
-    player-packet: "%Player% sent a magic packet includes {:}"
-    system: "Somebody sent a chat contains {jndi:}, but we don't say who did this :P"
+    player-packet: "%Player% sent a special packet includes {:}"
+    system: "Somebody sent a chat contains {jndi:}, but we won't say who did this :P"
 
 # Send the payload back to exploiter
 repeat-back-to-exploiter: true


### PR DESCRIPTION
I've noticed that the type of the context is still assignable to Context but it is not equals to the javax.naming.Context. And it would also lead further issues with newer version of log4j, which has disabled the JndiManager (but still be able to re-enable it via configuration but no one cares). This version has fixed the issues and could keep the server running normally.